### PR TITLE
Improve code quality

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -15,10 +15,18 @@ import duke.util.Ui;
  * @author Jicson Toh
  */
 public class Duke {
+    private static final String FILE_PATH = "data/data.txt";
     private Storage storage;
     private TaskList tasks;
     private Ui ui;
     private Parser parser;
+
+    /**
+     * Default constructor if no file path specified
+     */
+    public Duke() {
+        this(FILE_PATH);
+    }
 
     /**
      * Constructor for Duke Class.
@@ -33,7 +41,7 @@ public class Duke {
     }
 
     public static void main(String[] args) {
-        new Duke("data/data.txt").run();
+        new Duke().run();
     }
 
     /**

--- a/src/main/java/duke/Main.java
+++ b/src/main/java/duke/Main.java
@@ -15,7 +15,7 @@ import javafx.stage.Stage;
  * @author Jicson Toh
  */
 public class Main extends Application {
-    private final Duke duke = new Duke("data/data.txt");
+    private final Duke duke = new Duke();
 
     @Override
     public void start(Stage stage) {


### PR DESCRIPTION
The default file path had to be explicitly stated when creating the Duke object and this requires the user to know the file path.

Store the default file path as a named constant.

By storing it as a named constant, the user does not need to know the file path when initialising the object. The Duke class will by default create the file in the default file path if no file path is specified.